### PR TITLE
Support global candidate retrieval for DISC evals.

### DIFF
--- a/sscd/CHANGELOG.md
+++ b/sscd/CHANGELOG.md
@@ -1,3 +1,6 @@
 July 18, 2022
 
 * Update license from CC-NC 4.0 International license to the MIT license.
+* Add a `--global_candidates` option to evaluate with a global candidate
+  limit K, rather than K per query.
+  This style of retrieval was used for the ISC descriptor track evaluations.


### PR DESCRIPTION
Global candidate retrieval chooses the "nearest" candidates globally, by
adding all candidates to a global heap, and choosing the 500K
highest-similarity candidates across all queries. This type of
retrieval was used in the ISC descriptor track.

The SSCD paper instead uses ordinary KNN retrieval (K=10, which also
produces 500k candidates).

Global candidate retrieval reduces uAP without score normalization
somewhat (-0.5% for `sscd_disc_mixup`, -1.9% for a similar model
trained on ImageNet, which is less calibrated on DISC), but
has negligible effects with score normalization (-0.03%).

Addresses issue #1